### PR TITLE
Make segmentmarkerlist optional

### DIFF
--- a/src/triangulateio.jl
+++ b/src/triangulateio.jl
@@ -285,11 +285,10 @@ function CTriangulateIO(tio::TriangulateIO)
     if ctio.numberofsegments>0
         ctio.segmentlist=pointer(tio.segmentlist)
 
-        if size(tio.segmentmarkerlist, 1) == 0 # use default value of 0
-            tio.segmentmarkerlist = fill(zero(Int32), ctio.numberofsegments)
+        if size(tio.segmentmarkerlist, 1) > 0
+            @assert size(tio.segmentmarkerlist, 1) == ctio.numberofsegments
+            ctio.segmentmarkerlist = pointer(tio.segmentmarkerlist)
         end
-        @assert size(tio.segmentmarkerlist, 1) == ctio.numberofsegments
-        ctio.segmentmarkerlist = pointer(tio.segmentmarkerlist)
     end
     
     ctio.numberofholes=size(tio.holelist,2)

--- a/src/triangulateio.jl
+++ b/src/triangulateio.jl
@@ -284,8 +284,12 @@ function CTriangulateIO(tio::TriangulateIO)
     ctio.numberofsegments=size(tio.segmentlist,2)
     if ctio.numberofsegments>0
         ctio.segmentlist=pointer(tio.segmentlist)
-        @assert size(tio.segmentmarkerlist,1)==ctio.numberofsegments
-        ctio.segmentmarkerlist=pointer(tio.segmentmarkerlist)
+
+        if size(tio.segmentmarkerlist, 1) == 0 # use default value of 0
+            tio.segmentmarkerlist = fill(zero(Int32), ctio.numberofsegments)
+        end
+        @assert size(tio.segmentmarkerlist, 1) == ctio.numberofsegments
+        ctio.segmentmarkerlist = pointer(tio.segmentmarkerlist)
     end
     
     ctio.numberofholes=size(tio.holelist,2)

--- a/test/test_triangulate2.jl
+++ b/test/test_triangulate2.jl
@@ -1,0 +1,26 @@
+module test_triangulate2
+using Triangulate
+
+function test()
+    #     *
+    #     |
+    #  *--*--*
+
+    triin = Triangulate.TriangulateIO(
+        pointlist = Float64[0.0 1.0 2.0 1.0
+                            0.0 0.0 0.0 1.0],
+        segmentlist = Int32[1 2 2
+                            2 3 4],
+        # don't give segmentmarkerlist !
+    )
+
+    (triout, vorout) = triangulate("peDQ", triin)
+
+    return all([
+        size(triout.pointlist, 2) == 4,
+        size(triout.trianglelist, 2) == 2,
+        size(triout.segmentlist, 2) == 3,
+    ])
+end
+
+end

--- a/test/test_triangulate2.jl
+++ b/test/test_triangulate2.jl
@@ -14,12 +14,12 @@ function test()
         # don't give segmentmarkerlist !
     )
 
-    (triout, vorout) = triangulate("peDQ", triin)
+    (triout, vorout) = triangulate("pcDQ", triin)
 
     return all([
         size(triout.pointlist, 2) == 4,
         size(triout.trianglelist, 2) == 2,
-        size(triout.segmentlist, 2) == 3,
+        size(triout.segmentlist, 2) == 5,
     ])
 end
 


### PR DESCRIPTION
In the docstring for `TriangulateIO`, it says:
```julia
    """
    An array of segment markers. Optional on input. If not set then
    segment markers on output default to zero.
    """
    segmentmarkerlist :: Array{Cint,1}
```

So I thought that I could supply only `segmentlist`, without `segmentmarkerlist`. But this actually fails when converting to `CTriangulateIO`.

I've added a (failing) test, and tried to change the behavior, to match the documentation. But it's still failing and I'm not sure how, because the test output only tells me that there was an ERROR.

I guess this managing of default values would be easiest to implement in an external constructor, but the `TriangulateIO` struct is explictly mutable, so it's difficult to check the invariant (if `segmentlist` is given, `segmentmarkerlist` must also be given). 