### PR TITLE
docs typo

### DIFF
--- a/src/triangulateio.jl
+++ b/src/triangulateio.jl
@@ -385,10 +385,10 @@ containing the output triangulation and the optional Voronoi tesselation.
 After a call to triangulate(), the valid fields of `out` and `vorout`
 will depend, in an obvious way, on the choice of switches used.  Note
 that when the 'p' switch is used, the pointers `holelist` and
-`regionlist` are copied from `tri_in' to the output, but no new space is
+`regionlist` are copied from `tri_in` to the output, but no new space is
 allocated;  On   the other hand, Triangle will never copy the `pointlist` pointer (or any 
-others); new space is allocated for `out.pointlist', or if the `N'
-switch is used, `out.pointlist' remains uninitialized. 
+others); new space is allocated for `out.pointlist`, or if the 'N'
+switch is used, `out.pointlist` remains uninitialized. 
 
 This is the list of switches used by triangle:
 


### PR DESCRIPTION
Fixes the mardown, which currently looks like:

<img width="472" alt="Schermafbeelding 2022-02-13 om 16 02 01" src="https://user-images.githubusercontent.com/6933510/153759282-f99de286-428d-4baf-9d90-4e8f8340a70d.png">
